### PR TITLE
Read the canonical microgo.topics.rider-location key

### DIFF
--- a/src/main/java/com/driver/location_saver/kafka/handler/DriverLocationHandler.java
+++ b/src/main/java/com/driver/location_saver/kafka/handler/DriverLocationHandler.java
@@ -23,7 +23,7 @@ public class DriverLocationHandler {
 
     @KafkaListener(
             id = "${kafka.listeners.rider-location.id}",
-            topics = "${kafka.topics.rider-location}",
+            topics = "${microgo.topics.rider-location}",
             groupId = "${kafka.consumers.rider-location.group-id}",
             containerFactory = "riderLocationListenerFactory"
     )

--- a/src/test/java/com/driver/location_saver/integration/RiderLocationKafkaTransferIT.java
+++ b/src/test/java/com/driver/location_saver/integration/RiderLocationKafkaTransferIT.java
@@ -67,7 +67,7 @@ class RiderLocationKafkaTransferIT {
     @Autowired
     private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
 
-    @Value("${kafka.topics.rider-location}")
+    @Value("${microgo.topics.rider-location}")
     private String riderLocationTopic;
 
     @Value("${kafka.listeners.rider-location.id}")

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,6 +3,6 @@ spring.config.import=optional:configserver:
 
 
 kafka.bootstrap-servers=localhost:9092
-kafka.topics.rider-location=rider.location
+microgo.topics.rider-location=rider.location
 kafka.consumers.rider-location.group-id=driver.location.group
 kafka.listeners.rider-location.id=riderLocationListener


### PR DESCRIPTION
> ⚠️ **Deploy order:** requires [centralized-config#18](https://github.com/hendafarhani/centralized-config/pull/18) merged and the config server redeployed. `@KafkaListener` fails startup on an unresolvable placeholder.

```diff
- topics = "${kafka.topics.rider-location}",
+ topics = "${microgo.topics.rider-location}",
```

**The topic on the wire is unchanged** — this service still reads `rider.location`. Only the lookup key changes.

## Why this one matters beyond tidiness

`kafka.topics.rider-location` was the **only** key name in the fleet holding different values in different services:

| service | value |
|---|---|
| `location-saver` (this one) | `rider.location` |
| `location-rider` | `rider.location` |
| `driver-location-streamer` | `driver.location.updated` |

A shared config file has one namespace for the whole fleet, so that key could only hold one value there — putting it in would have silently repointed one of these services at the wrong topic. That is why its alias had to stay in each service file.

With this service and [the streamer](https://github.com/hendafarhani/driver-location-streamer/pull/3) both on canonical keys, only `location-rider` still uses the old name — and no service in `.gitmodules` claims that application name, so it may well be dead.

## Scope

| file | change |
|---|---|
| `DriverLocationHandler.java:26` | `@KafkaListener` topic |
| `RiderLocationKafkaTransferIT.java:70` | `@Value` |
| `src/test/resources/application.properties` | key renamed, value unchanged |

Consumer group id and listener id are untouched — each service must keep its own.

Verified: `mvn test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)